### PR TITLE
Feat/server api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.0.1",
         "next": "13.5.4",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-redux": "^9.0.4"
       },
       "devDependencies": {
         "@storybook/addon-essentials": "^7.4.6",
@@ -4214,6 +4216,29 @@
         "@babel/runtime": "^7.13.10"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.0.1.tgz",
+      "integrity": "sha512-fxIjrR9934cmS8YXIGd9e7s1XRsEU++aFc9DVNMFMRTM5Vtsg2DCRMj21eslGtDt43IUf9bJL3h5bwUlZleibA==",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.0",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.5.1.tgz",
@@ -6290,7 +6315,7 @@
       "version": "15.7.8",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.8.tgz",
       "integrity": "sha512-kMpQpfZKSCBqltAJwskgePRaYRFukDkm1oItcAbC3gNELR20XIBcN9VRgg4+m8DKsTfkWeA4m4Imp4DDuWy7FQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.8",
@@ -6308,7 +6333,7 @@
       "version": "18.2.25",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.25.tgz",
       "integrity": "sha512-24xqse6+VByVLIr+xWaQ9muX1B4bXJKXBbjszbld/UEDslGLY53+ZucF44HCmLbMPejTzGG9XgR+3m2/Wqu1kw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -6328,7 +6353,7 @@
       "version": "0.16.4",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.4.tgz",
       "integrity": "sha512-2L9ifAGl7wmXwP4v3pN4p2FLhD0O1qsJpvKmNin5VA8+UvNVb447UDaAEV6UdrkA+m/Xs58U1RFps44x6TFsVQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.3",
@@ -6362,6 +6387,11 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
       "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==",
       "dev": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.28",
@@ -8787,7 +8817,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -11465,6 +11495,15 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/immutable": {
@@ -14494,6 +14533,32 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-redux": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.0.4.tgz",
+      "integrity": "sha512-9J1xh8sWO0vYq2sCxK2My/QO7MzUMRi3rpiILP/+tDr8krBHixC6JMM17fMK88+Oh3e4Ae6/sHIhNBgkUivwFA==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "react-native": ">=0.69",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -14740,6 +14805,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.0.tgz",
+      "integrity": "sha512-blLIYmYetpZMET6Q6uCY7Jtl/Im5OBldy+vNPauA8vvsdqyt66oep4EUpAMWNHauTC6xa9JuRPhRB72rY82QGA=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -14934,6 +15012,11 @@
       "engines": {
         "node": ">=0.10.5"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.0.1.tgz",
+      "integrity": "sha512-D72j2ubjgHpvuCiORWkOUxndHJrxDaSolheiz5CO+roz8ka97/4msh2E8F5qay4GawR5vzBt5MkbDHT+Rdy/Wg=="
     },
     "node_modules/resolve": {
       "version": "1.22.6",
@@ -16789,6 +16872,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.0.1",
     "next": "13.5.4",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-redux": "^9.0.4"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.4.6",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,12 @@
+'use client'
 import type { Metadata } from 'next';
 
 import { Header } from '@/components/header';
 import { Footer } from '@/components/footer';
+import { Provider } from 'react-redux';
+import { store } from '@/services/store';
 
 import './globals.scss';
-
-export const metadata: Metadata = {
-  title: 'Литературная Москва - клуб любителей литературы и путешествий',
-  description: 'Проект «Литературная Москва». Клуб любителей литературы и путешествий. Авторские литературные экскурсии',
-}
 
 export default function RootLayout({
   children,
@@ -16,14 +14,16 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="ru">
-      <body className='body'>
-        <Header />
-        <main className='main'>
-          {children}
-        </main>
-        <Footer />
-      </body>
-    </html>
+    <Provider store={store}>
+      <html lang="ru">
+        <body className='body'>
+          <Header />
+          <main className='main'>
+            {children}
+          </main>
+          <Footer />
+        </body>
+      </html>
+    </Provider>
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,17 @@
+'use client'
 import { MainArticle } from '@/components/main-article';
 import { Showcase } from '@/components/showcase';
 import { Guides } from '@/components/guides';
+import { Provider } from 'react-redux';
+import { store } from '@/services/store';
 
 export default function Home() {
   return (
-    <>
-      <MainArticle />
-      <Showcase />
-      <Guides />
+    <><Provider store={store}>
+        <MainArticle />
+        <Showcase />
+        <Guides />
+      </Provider>
     </>
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,11 +7,12 @@ import { store } from '@/services/store';
 
 export default function Home() {
   return (
-    <><Provider store={store}>
+    <>
+    {/* <Provider store={store}> */}
         <MainArticle />
         <Showcase />
         <Guides />
-      </Provider>
+      {/* </Provider> */}
     </>
   );
 };

--- a/src/app/trip/[slug]/page.tsx
+++ b/src/app/trip/[slug]/page.tsx
@@ -1,3 +1,4 @@
+'use client'
 import Image from 'next/image';
 
 import { Breadcrumbs } from '@/components/breadcrumps';
@@ -6,6 +7,9 @@ import { TripRequest } from '@/components/trip-request';
 import { Location } from '@/utils/types';
 
 import styles from './trip.module.scss';
+import { usePathname } from 'next/navigation';
+import { useGetTripQuery } from '@/services/api';
+import { skipToken } from '@reduxjs/toolkit/query';
 
 type TripPageProps = {
   location: Location;
@@ -29,62 +33,81 @@ const mockData: TripPageProps = {
   price: 3500,
 };
 
-export default function TripPage() {
-  const { location, title, subtitle, date, text, pic, groups, price } =
-    mockData;
+// {
+//   "id": 2,
+//   "createdAt": "2023-12-15T12:53:21.373Z",
+//   "updatedAt": "2023-12-15T12:53:21.373Z",
+//   "name": "Булгаковский дом",
+//   "subtitle": "Музей-театр \"Дом Булгакова\"",
+//   "season": "winter",
+//   "type": "excursion",
+//   "location": "capital",
+//   "description": "Описание экскурсии. Пусть в этот раз оно будет чуть длиннее одного слова, чтобы можно было посмотреть на длинное описание и как оно выглядит в общей таблице, а также на странице редактирования активности.",
+//   "slug": "dom-bulgakova",
+//   "image": "https://kudamoscow.ru/uploads/7d43773e67a1c60fb31d5c9678ec6522.jpg",
+//   "isActive": true,
+//   "isDeleted": false
+// }
+
+export default function TripPage({ params }) {
+  const pathname = usePathname();
+  console.log(params.slug)
+  const { data: tripData, isLoading, isSuccess } = useGetTripQuery(params.slug);
 
   const tripLocationClass =
-    location === Location.Region
+    tripData?.location === Location.Region
       ? 'trip_location_region'
       : 'trip_location_capital';
   const subtitleLocationClass =
-    location === Location.Region
+    tripData?.location === Location.Region
       ? 'trip__subtitle_location_region'
       : 'trip__subtitle_location_capital';
   const commentLocationClass =
-    location === Location.Region
+    tripData?.location === Location.Region
       ? 'trip__comment_location_region'
       : 'trip__comment_location_capital';
   const priceLocationClass =
-    location === Location.Region
+    tripData?.location === Location.Region
       ? 'price__value_location_region'
       : 'price__value_location_capital';
 
   return (
     <section className={`${styles['trip']} ${styles[tripLocationClass]}`}>
+      {isSuccess &&
       <div className={styles['trip__container']}>
         <Breadcrumbs />
         <div className={styles['trip__section']}>
-          <Image
+          {/* <Image
             className={styles['trip__pic']}
-            src={pic}
-            alt={title}
+            src={tripData.image}
+            alt={tripData.name}
             width={420}
             height={625}
-          />
+          /> */}
+          <img className={styles['trip__pic']} src={tripData.image} alt={tripData.name}/>
           <div className={styles['trip__content']}>
             <div className={styles['trip__header']}>
               <div className={styles['trip__desc']}>
-                {title.length > 0 && (
-                  <h1 className={styles['trip__title']}>{title}</h1>
+                {tripData.name.length > 0 && (
+                  <h1 className={styles['trip__title']}>{tripData.name}</h1>
                 )}
-                {subtitle.length > 0 && (
+                {tripData.subtitle.length > 0 && (
                   <span
                     className={`${styles['trip__subtitle']} ${styles[subtitleLocationClass]}`}
                   >
-                    {subtitle}
+                    {tripData.subtitle}
                   </span>
                 )}
               </div>
-              <TripDate location={location} date={date ? date : undefined} />
+              <TripDate location={tripData.location} date={tripData.date ? tripData.date : undefined} />
             </div>
-            <p className={styles['trip__text']}>{text}</p>
-            {price && price > 0 && (
+            <p className={styles['trip__text']}>{tripData.description}</p>
+            {tripData.price && tripData.price > 0 && (
               <div className={styles['price']}>
                 <span
                   className={`${styles['price__value']} ${styles[priceLocationClass]}`}
                 >
-                  {price} <span className={styles['price__currency']}>₽</span>
+                  {tripData.price} <span className={styles['price__currency']}>₽</span>
                 </span>
                 <span className={styles['price__persons']}>
                   Стоимость для 1 чел.
@@ -97,10 +120,10 @@ export default function TripPage() {
                 </p>
               </div>
             )}
-            <TripRequest location={location} groups={groups} />
+            <TripRequest location={tripData.location} groups={true} />
           </div>
         </div>
-      </div>
+      </div>}
     </section>
   );
 }

--- a/src/app/trip/[slug]/page.tsx
+++ b/src/app/trip/[slug]/page.tsx
@@ -10,6 +10,7 @@ import styles from './trip.module.scss';
 import { usePathname } from 'next/navigation';
 import { useGetTripQuery } from '@/services/api';
 import { skipToken } from '@reduxjs/toolkit/query';
+import { Params } from 'next/dist/shared/lib/router/utils/route-matcher';
 
 type TripPageProps = {
   location: Location;
@@ -51,10 +52,11 @@ const mockData: TripPageProps = {
 //   "isDeleted": false
 // }
 
-export default function TripPage({ params }) {
+export default function TripPage({ params }:Params) {
   const pathname = usePathname();
-  console.log(params.slug)
-  const { data: tripData, isLoading, isSuccess } = useGetTripQuery(params.slug);
+  // console.log(params.slug);
+  // console.log(pathname);
+  const { data: tripData, isSuccess } = useGetTripQuery(params.slug);
 
   const tripLocationClass =
     tripData?.location === Location.Region
@@ -122,7 +124,13 @@ export default function TripPage({ params }) {
                 </p>
               </div>
             )}
-            <TripRequest location={tripData.location} groups={true} />
+            <TripRequest 
+            location={tripData.location} 
+            groups={true} 
+            availableDates={['01.04.2024','01.05.2024']} 
+            path={pathname}
+            eventName={tripData.name}
+            eventId={tripData.id}/>
           </div>
         </div>
       </div>}

--- a/src/app/trip/[slug]/trip.module.scss
+++ b/src/app/trip/[slug]/trip.module.scss
@@ -1,4 +1,4 @@
-@use '../../app/globals.scss';
+@use '../../../app/globals.scss';
 
 .trip {
   padding: 40px 0 60px;
@@ -36,8 +36,10 @@
 
   &__pic {
     flex-shrink: 0;
-    object-fit: contain;
+    object-fit: cover;
     border-radius: 40px;
+    width: 420px;
+    height: 625px;
   }
 
   &__header {

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -15,13 +15,12 @@ type CardProps = {
 export const Card = ({location, picture, name, extraName }:CardProps) => {
     return (
         <Link href='/' className={styles.card}>
-            {/* когда появятся картинки на беке, заменю img на <Image /> */}
             <img className={styles.image} src={picture} alt='обложка экскурсии'/>
             <Button 
             buttonType={ButtonType.Card}
             label={name}
-            text={extraName}
-            location={location === 'Moscow' ? Location.Capital : Location.Region}
+            text={extraName ?? ''}
+            location={location === 'capital' ? Location.Capital : Location.Region}
             extraClass={styles.button}/>
         </Link>
     )

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -10,11 +10,12 @@ type CardProps = {
     picture: string,
     name: string,
     extraName?: string,
+    slug: string
 }
 
-export const Card = ({location, picture, name, extraName }:CardProps) => {
+export const Card = ({location, picture, name, extraName, slug }:CardProps) => {
     return (
-        <Link href='/' className={styles.card}>
+        <Link href={`/trip/${slug}`} className={styles.card}>
             <img className={styles.image} src={picture} alt='обложка экскурсии'/>
             <Button 
             buttonType={ButtonType.Card}

--- a/src/components/filter-bar/filter-bar.tsx
+++ b/src/components/filter-bar/filter-bar.tsx
@@ -17,11 +17,11 @@ export const FilterBar = () => {
     };
 
     const handleClickMoscow = () => {
-        setSelectedFilter('moscow');
+        setSelectedFilter('capital');
     };
 
     const handleClickOthers = () => {
-        setSelectedFilter('from-moscow');
+        setSelectedFilter('region');
     };
 
     useEffect(()=> {

--- a/src/components/modal/modal.module.scss
+++ b/src/components/modal/modal.module.scss
@@ -15,7 +15,6 @@
 .container {
   position: relative;
   width: 600px;
-  height: 650px;
   background-color: globals.$sub-primary-color;
   border-radius: 29px;
   padding: 20px 30px;
@@ -36,5 +35,25 @@
 
 .headline {
   margin: 0 0 25px;
-  color: #6A898B;
+  color: globals.$secondary-color;
+}
+
+.eventTextWrapper {
+  display: flex;
+  flex-direction: row;
+  column-gap: 24px;
+  flex-wrap: wrap;
+  align-items: baseline;
+}
+
+.subtitle {
+  margin: 0 0 25px;
+  font-size: 24px;
+  opacity: 0.6;
+}
+
+.span {
+  margin: 0;
+  font-size: 24px;
+  opacity: 0.6;
 }

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -8,11 +8,11 @@ type ModalProps = {
   title: string;
   children: ReactElement;
   closeFn: () => void;
+  subtitle: string;
 };
 
-export const Modal = ({ title, children, closeFn }: ModalProps) => {
-  const [_, setState] = useState(false);
-  let targetEl: HTMLElement | null = document.getElementById('modals');
+export const Modal = ({ title, subtitle, children, closeFn }: ModalProps) => {
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -22,16 +22,18 @@ export const Modal = ({ title, children, closeFn }: ModalProps) => {
     };
   }, []);
 
-  useLayoutEffect(() => {
-    if (targetEl === null) {
-      targetEl = document.getElementById('modals');
-      setState((prev) => !prev);
-    }
-  }, [targetEl]);
+  useEffect(() => {
+    setMounted(true)
+    document.body.style.overflow = 'hidden';
+  
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, []);
 
   return (
     <>
-      {targetEl !== null &&
+      {mounted ?
         createPortal(
           <div className={styles.modal}>
             <Overlay onClick={closeFn} />
@@ -42,11 +44,16 @@ export const Modal = ({ title, children, closeFn }: ModalProps) => {
                 title="Закрыть окно"
               ></button>
               <h1 className={styles.headline}>{title}</h1>
+              <div className={styles.eventTextWrapper}>
+                <p className={styles.span}>На посещение мероприятия:</p>
+                <h2 className={styles.subtitle}>{subtitle}</h2>
+              </div>
               <div className={styles.elements}>{children}</div>
             </div>
           </div>,
-          targetEl
-        )}
+          document.body
+        )
+      : null}
     </>
   );
 };

--- a/src/components/request-form/request-form.tsx
+++ b/src/components/request-form/request-form.tsx
@@ -8,10 +8,14 @@ import styles from './request-form.module.scss';
 type RequestFormProps = {
   onSubmit: (data: RequestData) => void;
   availableDates: Array<string>;
+  eventName: string;
+  eventId: string;
 };
 
-export const RequestForm = ({ onSubmit, availableDates }: RequestFormProps) => {
+export const RequestForm = ({ onSubmit, eventName, eventId, availableDates }: RequestFormProps) => {
   const [data, setData] = useState<RequestData>({
+    event: eventName,
+    id: eventId,
     name: '',
     phone: '',
     email: '',

--- a/src/components/showcase/showcase.tsx
+++ b/src/components/showcase/showcase.tsx
@@ -6,55 +6,11 @@ import { FilterBar } from '../filter-bar/index'
 import styles from './showcase.module.scss'
 import { useGetActivitiesByFilterQuery } from '@/services/api'
 
-export const MockData = [
-    {
-        location: 'Moscow',
-        name: 'Москва Грузинская',
-        picture: 'https://photos.wikimapia.org/p/ot2/00/00/03/65/93_big.jpg'
-    },
-    {
-        location: 'Moscow',
-        name: 'Михаил Булгаков - начинающий москвич',
-        picture: 'https://moscowseasons.com/uploads/2021/05/28/60b0b1782d54a.jpeg'
-    },
-    {
-        location: 'Moscow',
-        name: 'Москва Грузинская',
-        extraName: 'Часть первая - Тверской бульвар и окрестности',
-        picture: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQl4N3Pw2_65nnhft8rveLM-_Y84moJrys2gQ&usqp=CAU'
-    },
-    {
-        location: 'Kaluga',
-        name: 'Калуга',
-        picture: 'https://cdn.tripster.ru/thumbs2/aeb33930-90f1-11ec-8cbb-e6705efd32d8.800x600.jpeg'
-    },
-    {
-        location: 'Zaraysk',
-        name: 'Зарайск',
-        picture: 'https://avatars.mds.yandex.net/get-marketcms/1490511/img-3e8cbf26-c0b4-4efd-9103-69441e2959ac.jpeg/optimize'
-    },
-    {
-        location: 'Moscow',
-        name: 'Москва',
-        picture: 'https://aif-s3.aif.ru/images/005/414/4eaa713a52b8235279d7e32f0e465c08.jpg'
-    },
-    {
-        location: 'Moscow',
-        name: 'Москва',
-        picture: 'https://i0.wp.com/design-fly.ru/wp-content/uploads/2017/08/%D0%B05.jpg'
-    },
-    {
-        location: 'Moscow',
-        name: 'Москва',
-        picture: 'https://progulkipomoskve.ru/foto/dom/5/malyj-xaritonevskij-pereulok-4-moskva.jpg'
-    }
-]
-
 export const Showcase = () => {
     const searchParams = useSearchParams();
     const selectedFilter = searchParams.get('tours');
     const { data: activities } = useGetActivitiesByFilterQuery(selectedFilter);
-    console.log(activities); 
+    // console.log(activities); 
 
     return (
         <section>
@@ -62,6 +18,9 @@ export const Showcase = () => {
             <div className={styles.container}>
                 <FilterBar/>
                 <ul className={styles.cardsZone} >
+                    {/* типы для activities и карточки описать позже, когда пойму, какие 
+                    будут изменения в ней после прикручивания дат и 
+                    евентов к активности */}
                     {activities?.map((eventCard) => {
                         return( 
                             <li key={eventCard.id}>

--- a/src/components/showcase/showcase.tsx
+++ b/src/components/showcase/showcase.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation'
 import { Card } from '../card/index'
 import { FilterBar } from '../filter-bar/index'
 import styles from './showcase.module.scss'
+import { useGetActivitiesByFilterQuery } from '@/services/api'
 
 export const MockData = [
     {
@@ -52,8 +53,8 @@ export const MockData = [
 export const Showcase = () => {
     const searchParams = useSearchParams();
     const selectedFilter = searchParams.get('tours');
-    // console.log(selectedFilter); 
-    // с помощью selectedFilter собираюсь делать запрос на бек за списком карточек
+    const { data: activities } = useGetActivitiesByFilterQuery(selectedFilter);
+    console.log(activities); 
 
     return (
         <section>
@@ -61,14 +62,14 @@ export const Showcase = () => {
             <div className={styles.container}>
                 <FilterBar/>
                 <ul className={styles.cardsZone} >
-                    {MockData.map((eventCard) => {
+                    {activities?.map((eventCard) => {
                         return( 
-                            <li key={MockData.indexOf(eventCard)}>
+                            <li key={eventCard.id}>
                                 <Card 
                                 name={eventCard.name}
                                 location={eventCard.location}
-                                picture={eventCard.picture}
-                                extraName={eventCard.extraName} />
+                                picture={eventCard.image}
+                                extraName={eventCard.subtitle} />
                             </li>
                         )
                     })}

--- a/src/components/showcase/showcase.tsx
+++ b/src/components/showcase/showcase.tsx
@@ -69,7 +69,8 @@ export const Showcase = () => {
                                 name={eventCard.name}
                                 location={eventCard.location}
                                 picture={eventCard.image}
-                                extraName={eventCard.subtitle} />
+                                extraName={eventCard.subtitle} 
+                                slug={eventCard.slug}/>
                             </li>
                         )
                     })}

--- a/src/components/trip-request/trip-request.tsx
+++ b/src/components/trip-request/trip-request.tsx
@@ -13,9 +13,12 @@ type TripRequestProps = {
   location: Location;
   groups: boolean;
   availableDates: Array<string>;
+  path: string;
+  eventName: string;
+  eventId: string;
 };
 
-export const TripRequest = ({ location, groups, availableDates }: TripRequestProps) => {
+export const TripRequest = ({ location, groups, availableDates, path, eventName, eventId }: TripRequestProps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const showRequestModal = searchParams.has('request');
@@ -26,19 +29,19 @@ export const TripRequest = ({ location, groups, availableDates }: TripRequestPro
       : 'request__comment_location_capital';
 
   const closeRequestModal = () => {
-    router.push('/trip', { scroll: false });
+    router.replace(path, { scroll: false });
   };
 
   const sendRequest = (data: RequestData) => {
-    console.log(data);
+    //console.log(data);
     closeRequestModal();
   };
 
   return (
     <>
       {showRequestModal && (
-        <Modal title="Оставить заявку" closeFn={closeRequestModal}>
-          <RequestForm onSubmit={sendRequest} availableDates={availableDates} />
+        <Modal title="Оставить заявку" subtitle={eventName} closeFn={closeRequestModal}>
+          <RequestForm eventId={eventId} eventName={eventName} onSubmit={sendRequest} availableDates={availableDates} />
         </Modal>
       )}
 
@@ -47,7 +50,7 @@ export const TripRequest = ({ location, groups, availableDates }: TripRequestPro
           buttonType={ButtonType.Request}
           label="Оставить заявку"
           location={location}
-          onClick={() => router.push('/trip?request', { scroll: false })}
+          onClick={() => router.push(`${path}?request`, { scroll: false })}
           extraClass={styles['request__button']}
         />
         {groups && (

--- a/src/components/trip-request/types.ts
+++ b/src/components/trip-request/types.ts
@@ -4,4 +4,6 @@ export type RequestData = {
   email: string;
   visitors: string;
   date: string;
+  event: string;
+  id: string;
 };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,6 @@
 import { FetchArgs, createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
-const URL = 'http://localhost:3000';
+const URL = 'http://localhost:3001';
 
 export const appApi = createApi({
     reducerPath: 'api',

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,19 @@
+import { FetchArgs, createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+const URL = 'http://localhost:3000';
+
+export const appApi = createApi({
+    reducerPath: 'api',
+    tagTypes: ['Activity', 'Event'],
+    baseQuery: fetchBaseQuery({ baseUrl: URL}),
+    endpoints: (build) => ({
+        getAllActivities: build.query({
+            query: () => `/activity`
+        }),
+        getActivitiesByFilter: build.query({
+            query: (params) => params ? `/activity?tours=${params}` : `/activity`
+        })
+    })
+})
+
+export const {useGetAllActivitiesQuery, useGetActivitiesByFilterQuery} = appApi;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -12,8 +12,11 @@ export const appApi = createApi({
         }),
         getActivitiesByFilter: build.query({
             query: (params) => params ? `/activity?tours=${params}` : `/activity`
+        }),
+        getTrip: build.query({
+            query: (slug) => `activity/trip/${slug}`
         })
     })
 })
 
-export const {useGetAllActivitiesQuery, useGetActivitiesByFilterQuery} = appApi;
+export const {useGetAllActivitiesQuery, useGetActivitiesByFilterQuery, useGetTripQuery} = appApi;

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -1,0 +1,16 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { appApi } from './api';
+
+export const store = configureStore({
+    reducer: {
+        [appApi.reducerPath]: appApi.reducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(appApi.middleware)
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/ui/button/button.module.scss
+++ b/src/ui/button/button.module.scss
@@ -1,7 +1,6 @@
 @use '../../app/globals.scss';
 
 .button {
-  position: relative;
   width: 220px;
   height: 75px;
   box-sizing: border-box;
@@ -84,6 +83,7 @@
 
   &_type {
     &_filter {
+      position: relative;
       width: 185px;
       box-shadow: 8px 4px 40px 0 rgba(0, 0, 0, 0.25);
     }


### PR DESCRIPTION
В этом пул-реквесте в проект добавлена **новая функциональность:**
- витрина с активностями строится не на моковых данных, а на активностях из БД,
- добавлены вложенные роуты с динамическим slug для каждой активности.

**Исправлено**: 
- баг с обновлением страницы при открытом попапе,
- расширены данные формы, которые будем отправлять для создания записи на евент,
- исправлен баг с позиционированием кнопки при перемещении назад по истории браузера,
- исправлен баг с повторно открывающимся попапом при перемещении назад по истории браузера.

По доработкам двигаюсь итерационно, поэтому на данный момент **не реализовано**:
- отправка данных формы на сервер,
- фильтрация витрины, 
- компонент-заглушка для главной страницы, если нет ни одной активности на витрине (активных нет, или не удалось их получить с сервера, причина может быть любая),